### PR TITLE
stateless command line parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,5 +94,10 @@ jobs:
       - name: build
         working-directory: test/meson_test_project
         run: |
-          colcon build
+          colcon build --event-handlers=console_direct+
           test -f install/meson_test_project/bin/meson_test_project
+
+      - name: reconfigure (buildtype=debug)
+        working-directory: test/meson_test_project
+        run: |
+          colcon build --event-handlers=console_direct+ --meson-args "--buildtype=debug"

--- a/colcon_meson/build.py
+++ b/colcon_meson/build.py
@@ -105,7 +105,6 @@ class MesonBuildTask(TaskExtensionPoint):
         super().__init__()
 
         self.meson_path = shutil.which("meson")
-        self.parser_setup = CommandLineParser().subparsers.choices["setup"]
 
     def add_arguments(self, *, parser: ArgumentParser):
         """Add new arguments to the colcon build argument parser.
@@ -155,7 +154,8 @@ class MesonBuildTask(TaskExtensionPoint):
         Returns:
             Namespace: parse args
         """
-        args = self.parser_setup.parse_args(cmdline)
+        parser_setup = CommandLineParser().subparsers.choices["setup"]
+        args = parser_setup.parse_args(cmdline)
         meson_cmd.parse_cmd_line_options(args)
         return args
 

--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -10,5 +10,6 @@ artifacts:
           distributions:
             - ubuntu:jammy
             - ubuntu:noble
+            - ubuntu:resolute
             - debian:bookworm
             - debian:trixie

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = colcon-meson
-version = 0.6.0
+version = 0.6.1
 project_urls =
     GitHub = https://github.com/colcon/colcon-meson
 author = Christian Rauch

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [colcon-meson]
 No-Python2:
 Depends3: python3-colcon-core (>= 0.10.0), python3-colcon-library-path, python3 (>= 3.8) | python3-importlib-metadata, meson (>= 0.60.0)
-Suite: jammy noble bookworm trixie
+Suite: jammy noble resolute bookworm trixie
 X-Python3-Version: >= 3.6
 Upstream-Version-Suffix: +upstream


### PR DESCRIPTION
Using the stateful command line parser via 'parser_setup' class member causes issues when default arguments are overridden by colcon meta files. Avoid this by initialising a local parser instance.